### PR TITLE
Fixed crash if regionRanging is null on Android

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -180,8 +180,10 @@ public class FlutterBeaconPlugin implements MethodCallHandler,
     try {
       FlutterBeaconPlugin.this.beaconManager.removeAllRangeNotifiers();
       FlutterBeaconPlugin.this.beaconManager.addRangeNotifier(rangeNotifier);
-      for (Region region : regionRanging) {
-        beaconManager.startRangingBeaconsInRegion(region);
+      if (regionRanging != null) {
+        for (Region region : regionRanging) {
+          beaconManager.startRangingBeaconsInRegion(region);
+        }
       }
     } catch (RemoteException e) {
       if (FlutterBeaconPlugin.this.eventSinkRanging != null) {


### PR DESCRIPTION
Plugin calls startRanging function with empty regionRanging array