### PR TITLE
Use AndroidX in example project

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M


### PR DESCRIPTION
Add AndroidX configuration in the grade.properties file of the example project to fix the following error at startup:

```
java.lang.NoClassDefFoundError: Failed resolution of:  android/support/v4/content/LocalBroadcastManager;
```

This might be the fix for #19.