### PR TITLE
Update altbeacon dependency version to 2.16.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ android {
 
 dependencies {
     api 'androidx.legacy:legacy-support-v4:1.0.0'
-    api 'org.altbeacon:android-beacon-library:2.16.2'
+    api 'org.altbeacon:android-beacon-library:2.16.3'
 }


### PR DESCRIPTION
Fixes an important altbeacon-related crash
https://github.com/AltBeacon/android-beacon-library/issues/887