### PR TITLE
fix initialize return bool value

### DIFF
--- a/ios/Classes/FlutterBeaconPlugin.m
+++ b/ios/Classes/FlutterBeaconPlugin.m
@@ -60,7 +60,7 @@
     if ([@"initialize" isEqualToString:call.method]) {
         [self initializeLocationManager];
         [self initializeCentralManager];
-        result(@(true));
+        result(@(YES));
         return;
     }
     


### PR DESCRIPTION
I have this error when initializeScanning on iOS, and fix it.

error log
===

```
flutter: Error caught by Crashlytics plugin <recordError>:
flutter: type 'int' is not a subtype of type 'bool'
flutter: 
#0      MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:321:13)
<asynchronous suspension>
#1      FlutterBeacon.initializeScanning (package:flutter_beacon/flutter_beacon.dart:65:33)
#2      WithButtonWidgetState.handleBeaconScan (package:chikanradar_mobile/ui/widgets/home/BottomWidget.dart:157:29)
#3      WithButtonWidgetState.build.<anonymous closure> (package:chikanradar_mobile/ui/widgets/home/BottomWidget.dart:128:17)
<asynchronous suspension>
#4      _InkResponseState._handleTap (package:flutter/src/material/ink_well.dart:706:14)
#5      _InkResponseState.build.<anonymous closure> (package:flutter/src/material/ink_well.dart:789:36)
#6      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:182:24)
#7      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:486:11)
#8      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:264:5)
#9      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:236:7)
#10     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:156:27)
#11     GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:222:20)
#12     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:198:22)
#13     GestureBinding._handlePointerEvent (package:flutter/src/gestures/binding.dart:156:7)
#14     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:102:7)
#15     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:86:7)
#16     _rootRunUnary (dart:async/zone.dart:1138:13)
#17     _CustomZone.runUnary (dart:async/zone.dart:1031:19)
#18     _CustomZone.runUnaryGuarded (dart:async/zone.dart:933:7)
#19     _invoke1 (dart:ui/hooks.dart:273:10)
#20     _dispatchPointerDataPacket (dart:ui/hooks.dart:182:5)
```

flutter doctor
======

```
[✓] Flutter (Channel stable, v1.12.13+hotfix.5, on Mac OS X 10.14.6 18G1012, locale ja-JP)
 
[!] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
    ! Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses
[✓] Xcode - develop for iOS and macOS (Xcode 11.0)
[✓] Android Studio (version 3.5)
[!] IntelliJ IDEA Community Edition (version 2018.3.6)
    ✗ Flutter plugin not installed; this adds Flutter specific functionality.
    ✗ Dart plugin not installed; this adds Dart specific functionality.
[✓] VS Code (version 1.41.1)
[✓] Connected device (2 available)
```