### PR TITLE
Android: Add location authorizationStatusChanged implementation

### DIFF
--- a/lib/beacon/authorization_status.dart
+++ b/lib/beacon/authorization_status.dart
@@ -87,10 +87,9 @@ class AuthorizationStatus {
 
   /// Shows that authorization has not been determined by user.
   ///
-  /// Only for iOS
   static const AuthorizationStatus notDetermined = AuthorizationStatus.init(
     'NOT_DETERMINED',
-    isAndroid: false,
+    isAndroid: true,
     isIOS: true,
   );
 }

--- a/lib/flutter_beacon.dart
+++ b/lib/flutter_beacon.dart
@@ -79,8 +79,7 @@ class FlutterBeacon {
 
   /// Check for the latest [AuthorizationStatus] from device.
   ///
-  /// For Android, this will return between [AuthorizationStatus.allowed]
-  /// or [AuthorizationStatus.denied] only.
+  /// For Android, this will return [AuthorizationStatus.allowed], [AuthorizationStatus.denied] or [AuthorizationStatus.notDetermined].
   Future<AuthorizationStatus> get authorizationStatus async {
     final status = await _methodChannel.invokeMethod('authorizationStatus');
     return AuthorizationStatus.parse(status);
@@ -170,7 +169,6 @@ class FlutterBeacon {
   }
 
   /// Start checking for location service authorization status changed.
-  /// This stream only enabled on iOS only.
   ///
   /// This will fires [AuthorizationStatus] whenever authorization status changed.
   Stream<AuthorizationStatus> authorizationStatusChanged() {


### PR DESCRIPTION
This pull request adds an Android implementation of the `authorizationStatusChanged` event channel that is already present in iOS.

It also adds support for the "`NOT_DETERMINED`" authorization status on Android.

This makes it easier to have cross platform flutter code listening to authorization changes on both platforms.

Incidentally, it also makes it easier to deal with concurrent `requestPermissions` calls on Android when used together with other plugins that might already have a permission request dialog - in that case, an app may listen for `NOT_DETERMINED` and try calling `requestAuthorization` again after a short delay.

* Implement `authorizationStatusChanged()` for Android
  (aka "`eventChannelAuthorizationStatus`")
  (previously only available on iOS)

* Add `AuthorizationStatus NOT_DETERMINED` on Android.
  Use this for all denied cases except where the user has
  checked "Don't Show Again".
  (This was previously an iOS-only status value)

* Better deal with concurrent `requestPermissions` prompts,
  for example of another flutter plugin has an active `requestPermissions` open.
  (This will trigger `onRequestPermissionsResult` with zero-length arrays,
  which should emit NOT_DETERMINED again)

* Also if `requestAuthorization` is called and permission was already granted,
  then emit `ALLOWED`, otherwise `authorizationStatusChanged()` might miss out
  on the fact that permission has been granted
  (possibly via a different plugin's `requestPermissions` routine)