### PR TITLE
iOS: Option for "whenInUse" and "always" location authorization permissions

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -126,6 +126,15 @@ public class FlutterBeaconPlugin implements MethodCallHandler,
       return;
     }
 
+    if (call.method.equals("setLocationAuthorizationTypeDefault")) {
+      // Android does not have the concept of "requestWhenInUse" and "requestAlways" like iOS does,
+      // so this method does nothing.
+      // (Well, in Android API 29 and higher, there is an "ACCESS_BACKGROUND_LOCATION" option,
+      //  which could perhaps be appropriate to add here as an improvement.)
+      result.success(true);
+      return;
+    }
+
     if (call.method.equals("authorizationStatus")) {
       result.success(checkLocationServicesPermission() ? "ALLOWED" : "DENIED");
       return;

--- a/lib/flutter_beacon.dart
+++ b/lib/flutter_beacon.dart
@@ -77,6 +77,17 @@ class FlutterBeacon {
     return await _methodChannel.invokeMethod('initializeAndCheck');
   }
 
+  /// Set the default AuthorizationStatus to use in requesting location authorization.
+  /// For iOS, this can be either [AuthorizationStatus.whenInUse] or [AuthorizationStatus.always].
+  /// For Android, this is not used.
+  ///
+  /// This method should be called very early to have an effect,
+  /// before any of the other initializeScanning or authorizationStatus getters.
+  ///
+  Future<bool> setLocationAuthorizationTypeDefault(AuthorizationStatus authorizationStatus) async {
+    return await _methodChannel.invokeMethod('setLocationAuthorizationTypeDefault', authorizationStatus.value);
+  }
+
   /// Check for the latest [AuthorizationStatus] from device.
   ///
   /// For Android, this will return between [AuthorizationStatus.allowed]


### PR DESCRIPTION
On iOS: Add "`flutterBeacon.setLocationAuthorizationTypeDefault()`" as a way to specify "whenInUse" or "always" as the desired location authorization status to request by default.

On Android, this method currently does nothing.

Previously, this plugin would always request the "Always" permission for location authorization on iOS.

By calling "`flutterBeacon.setLocationAuthorizationTypeDefault(AuthorizationStatus.whenInUse)`" early, it is possible to lower the permission requirement on iOS to just "when in use".