### PR TITLE
Add customizable scan time period on Android. Closes #76

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -3,6 +3,7 @@ package com.flutterbeacon;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.RemoteException;
 
 import androidx.annotation.NonNull;
 
@@ -158,6 +159,17 @@ public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, Method
       if (beaconManager != null && !beaconManager.isBound(beaconScanner.beaconConsumer)) {
         this.flutterResult = result;
         this.beaconManager.bind(beaconScanner.beaconConsumer);
+
+        if (call.hasArgument("scanPeriod")) {
+          int scanPeriod = call.argument("scanPeriod");
+          this.beaconManager.setForegroundScanPeriod(scanPeriod);
+          try {
+            this.beaconManager.updateScanPeriods();
+          } catch (RemoteException e) {
+            result.success(false);
+          }
+        }
+
         return;
       }
 

--- a/lib/flutter_beacon.dart
+++ b/lib/flutter_beacon.dart
@@ -55,9 +55,13 @@ class FlutterBeacon {
   /// This information does not change from call to call. Cache it.
   Stream<AuthorizationStatus> _onAuthorizationStatus;
 
+  /// Customize duration of the beacon scan on the Android Platform.
+  static var androidScanPeriod;
+
   /// Initialize scanning API.
   Future<bool> get initializeScanning async {
-    final result = await _methodChannel.invokeMethod('initialize');
+    final result = await _methodChannel.invokeMethod('initialize',
+        {"scanPeriod": androidScanPeriod});
 
     if (result is bool) {
       return result;


### PR DESCRIPTION
This PR adds the ability for developer to set a custom scan time for the Android beacon scanner.

For example, using:
```
    flutterBeacon.androidScanPeriod = 300;
    await flutterBeacon.initializeScanning;
```

will fire the ranging callback every 300ms instead of the default AltBeacon library value.