### PR TITLE
fix: Add return statements in setScanPeriod and setBetweenScanPeriod to prevent IllegalStateException (#146)

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -178,8 +178,10 @@ public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, Method
       try {
         this.beaconManager.updateScanPeriods();
         result.success(true);
+        return;
       } catch (RemoteException e) {
         result.success(false);
+        return;
       }
     }
 
@@ -189,8 +191,10 @@ public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, Method
       try {
         this.beaconManager.updateScanPeriods();
         result.success(true);
+        return;
       } catch (RemoteException e) {
         result.success(false);
+        return;
       }
     }
 


### PR DESCRIPTION
Thank you for creating this useful library!

Closes #146

### Fix:

Added `return;` statements** after `result.success(true)` and `result.error(...)` in both `setScanPeriod` and `setBetweenScanPeriod` methods.

### Reason

The `setScanPeriod` and `setBetweenScanPeriod` methods in the `FlutterBeaconPlugin` were missing `return` statements after invoking `result.success` or `result.error`.
This omission caused the methods to continue execution, inadvertently calling `result.notImplemented()`,
which led to an `IllegalStateException` due to multiple responses being sent for a single method call.
