### PR TITLE
feature: Add background scan period APIs for Android

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -194,6 +194,32 @@ public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, Method
       }
     }
 
+    if (call.method.equals("setBackgroundScanPeriod")) {
+      int scanPeriod = call.argument("scanPeriod");
+      this.beaconManager.setBackgroundScanPeriod(scanPeriod);
+      try {
+        this.beaconManager.updateScanPeriods();
+        result.success(true);
+        return;
+      } catch (RemoteException e) {
+        result.success(false);
+        return;
+      }
+    }
+
+    if (call.method.equals("setBackgroundBetweenScanPeriod")) {
+      int betweenScanPeriod = call.argument("betweenScanPeriod");
+      this.beaconManager.setBackgroundBetweenScanPeriod(betweenScanPeriod);
+      try {
+        this.beaconManager.updateScanPeriods();
+        result.success(true);
+        return;
+      } catch (RemoteException e) {
+        result.success(false);
+        return;
+      }
+    }
+
     if (call.method.equals("setLocationAuthorizationTypeDefault")) {
       // Android does not have the concept of "requestWhenInUse" and "requestAlways" like iOS does,
       // so this method does nothing.

--- a/ios/Classes/FlutterBeaconPlugin.m
+++ b/ios/Classes/FlutterBeaconPlugin.m
@@ -231,6 +231,20 @@
         result(@(YES));
         return;
     }
+
+    if ([@"setBackgroundScanPeriod" isEqualToString:call.method]) {
+        // do nothing
+
+        result(@(YES));
+        return;
+    }
+
+    if ([@"setBackgroundBetweenScanPeriod" isEqualToString:call.method]) {
+        // do nothing
+
+        result(@(YES));
+        return;
+    }
     
     if ([@"openApplicationSettings" isEqualToString:call.method]) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];

--- a/lib/flutter_beacon.dart
+++ b/lib/flutter_beacon.dart
@@ -190,6 +190,26 @@ class FlutterBeacon {
         'setBetweenScanPeriod', {"betweenScanPeriod": scanPeriod});
   }
 
+  /// Customize the duration of the beacon scan in the background on the Android platform.
+  ///
+  /// [scanPeriod] specifies the duration of the scan in milliseconds.
+  ///
+  /// Returns a [Future] that completes with `true` if the operation was successful.
+  Future<bool> setBackgroundScanPeriod(int scanPeriod) async {
+    return await _methodChannel
+        .invokeMethod('setBackgroundScanPeriod', {"scanPeriod": scanPeriod});
+  }
+
+  /// Customize the duration between beacon scans in the background on the Android platform.
+  ///
+  /// [scanPeriod] specifies the wait time between scans in milliseconds.
+  ///
+  /// Returns a [Future] that completes with `true` if the operation was successful.
+  Future<bool> setBackgroundBetweenScanPeriod(int scanPeriod) async {
+    return await _methodChannel.invokeMethod(
+        'setBackgroundBetweenScanPeriod', {"betweenScanPeriod": scanPeriod});
+  }
+
   /// Close scanning API.
   Future<bool> get close async {
     final result = await _methodChannel.invokeMethod('close');

--- a/test/flutter_beacon_test.dart
+++ b/test/flutter_beacon_test.dart
@@ -74,6 +74,14 @@ void main() {
         return true;
       }
 
+      if (method == 'setBackgroundScanPeriod') {
+        return true;
+      }
+
+      if (method == 'setBackgroundBetweenScanPeriod') {
+        return true;
+      }
+
       throw MissingPluginException(
           'No implementation found for method $method on channel ${channel.name}');
     });
@@ -282,6 +290,20 @@ void main() {
     test('SetBetweenScanPeriod return "true"', () async {
       expect(
         await flutterBeacon.setBetweenScanPeriod(400),
+        true,
+      );
+    });
+
+    test('SetBackgroundScanPeriod return "true"', () async {
+      expect(
+        await flutterBeacon.setBackgroundScanPeriod(1000),
+        true,
+      );
+    });
+
+    test('SetBackgroundBetweenScanPeriod return "true"', () async {
+      expect(
+        await flutterBeacon.setBackgroundBetweenScanPeriod(400),
         true,
       );
     });


### PR DESCRIPTION
### Summary

This PR introduces two new APIs, setBackgroundScanPeriod and setBackgroundBetweenScanPeriod, to customize beacon scanning behavior when the application is running in the background on Android devices.
These methods complement the existing setScanPeriod and setBetweenScanPeriod APIs, which configure scanning while the app is in the foreground. 

### Added Methods:

- Future<bool> setBackgroundScanPeriod(int scanPeriod): Sets the duration for beacon scanning in the background.
- Future<bool> setBackgroundBetweenScanPeriod(int scanPeriod): Sets the wait time between consecutive beacon scans in the background.


### References:

- [BeaconManager#setBackgroundScanPeriod](https://altbeacon.github.io/android-beacon-library/javadoc/org/altbeacon/beacon/BeaconManager.html#setBackgroundScanPeriod(long))
- [BeaconManager#setBackgroundBetweenScanPeriod](https://altbeacon.github.io/android-beacon-library/javadoc/org/altbeacon/beacon/BeaconManager.html#setBackgroundBetweenScanPeriod(long))