### PR TITLE
Refactored FlutterBeaconPlugin by removing deprecated registerWith method

### DIFF
--- a/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
+++ b/android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java
@@ -20,7 +20,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, MethodCallHandler,
     PluginRegistry.RequestPermissionsResultListener,
@@ -52,13 +51,6 @@ public class FlutterBeaconPlugin implements FlutterPlugin, ActivityAware, Method
 
   public FlutterBeaconPlugin() {
 
-  }
-
-  public static void registerWith(Registrar registrar) {
-    final FlutterBeaconPlugin instance = new FlutterBeaconPlugin();
-    instance.setupChannels(registrar.messenger(), registrar.activity());
-    registrar.addActivityResultListener(instance);
-    registrar.addRequestPermissionsResultListener(instance);
   }
 
   @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,6 @@ class MainApp extends StatelessWidget {
         brightness: Brightness.light,
         primarySwatch: primary,
         appBarTheme: themeData.appBarTheme.copyWith(
-          brightness: Brightness.light,
           elevation: 0.5,
           color: Colors.white,
           actionsIconTheme: themeData.primaryIconTheme.copyWith(
@@ -29,12 +28,15 @@ class MainApp extends StatelessWidget {
           ),
           iconTheme: themeData.primaryIconTheme.copyWith(
             color: primary,
-          ),
-          textTheme: themeData.primaryTextTheme.copyWith(
-            headline6: themeData.textTheme.headline6?.copyWith(
+          ), systemOverlayStyle: SystemUiOverlayStyle.dark, toolbarTextStyle: themeData.primaryTextTheme.copyWith(
+            titleLarge: themeData.textTheme.titleLarge?.copyWith(
               color: primary,
             ),
-          ),
+          ).bodyMedium, titleTextStyle: themeData.primaryTextTheme.copyWith(
+            titleLarge: themeData.textTheme.titleLarge?.copyWith(
+              color: primary,
+            ),
+          ).titleLarge,
         ),
       ),
       darkTheme: ThemeData(

--- a/example/lib/view/app_broadcasting.dart
+++ b/example/lib/view/app_broadcasting.dart
@@ -159,8 +159,7 @@ class _TabBroadcastingState extends State<TabBroadcasting> {
 
   Widget get buttonBroadcast {
     final ButtonStyle raisedButtonStyle = ElevatedButton.styleFrom(
-      onPrimary: Colors.white,
-      primary: broadcasting ? Colors.red : Theme.of(context).primaryColor,
+      foregroundColor: Colors.white, backgroundColor: broadcasting ? Colors.red : Theme.of(context).primaryColor,
       minimumSize: Size(88, 36),
       padding: EdgeInsets.symmetric(horizontal: 16),
       shape: const RoundedRectangleBorder(


### PR DESCRIPTION
This pull request includes several changes to improve code consistency, modernize the codebase, and update the UI theme. The most important changes include removing deprecated methods, updating the UI theme, and refactoring button styles.

Codebase modernization:

* [`android/src/main/java/com/flutterbeacon/FlutterBeaconPlugin.java`]: Removed the deprecated `registerWith` method and the `Registrar` import, as they are no longer needed with the updated Flutter plugin API. 

UI theme updates:

* [`example/lib/main.dart`]: Updated the `AppBarTheme` to use `systemOverlayStyle` and the new `titleLarge` text style for better compatibility with the latest Flutter versions.

Button style refactoring:

* [`example/lib/view/app_broadcasting.dart`]: Refactored the button style to use `foregroundColor` and `backgroundColor` instead of the older `onPrimary` and `primary` properties for consistency with the latest Flutter API.